### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: Docker Building
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DaanSelen/stardew-multiplayer/security/code-scanning/2](https://github.com/DaanSelen/stardew-multiplayer/security/code-scanning/2)

To fix the problem, add an explicit `permissions:` block to the workflow or at the job level to restrict the `GITHUB_TOKEN` to only the minimal access required. Based on a review of the workflow steps, most actions interact with Docker Hub and local files, and do not require `write` permissions on the repository or its contents. Actions such as `docker/build-push-action`, `actions/checkout`, and `docker/scout-action` only require read access to repository contents, if any. Thus, the best fix is to add a `permissions:` block at the workflow level (just below the `name:` or `on:` block) like:

```yaml
permissions:
  contents: read
```

If further permissions are required by individual jobs for actions such as creating pull requests or managing issues, these can be added at the job level. However, for the purposes of this workflow as presented, `contents: read` is sufficient and safest.

You should edit `.github/workflows/docker.yml`, inserting the following block after the workflow `name:` and before `on:`. No imports or other code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
